### PR TITLE
Implement single file conversion functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,21 @@ You might consider adding the `target/relase` folder to your PATH to run `lean2m
 Basic usage:
 
 ```bash
-lean2md <lean_src_dir> <md_tgt_dir>     # Convert Lean files to Markdown
+lean2md <file.lean>                     # Convert a single file to <file.md>
+lean2md <lean_src_file> <md_tgt_file>   # Convert a specific file to a specific target
+lean2md <lean_src_dir> <md_tgt_dir>     # Convert all Lean files in a directory
 lean2md --version                       # Display version information
 ```
 
 Example:
 
 ```bash
+# Convert a single file
+lean2md MyModule.lean                   # Creates MyModule.md in the same directory
+
+# Convert a file to a specific location
+lean2md src/MyModule.lean docs/module.md
+
 # Convert all .lean files in the Geometry directory to .md files in the docs directory
 lean2md Geometry docs
 ```
@@ -55,7 +63,7 @@ lean2md Geometry docs
 When running with cargo:
 
 ```bash
-cargo run -- <lean_src_dir> <md_tgt_dir>
+cargo run -- -- <arguments>                # e.g., cargo run -- MyModule.lean
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ lean2md Geometry docs
 When running with cargo:
 
 ```bash
-cargo run -- -- <arguments>                # e.g., cargo run -- MyModule.lean
+cargo run -- <arguments>                # e.g., cargo run -- MyModule.lean
 ```
 
 ## Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,4 @@
 mod lean2md_core; // Move core functionality to this module
 
 // Export public functions for other crates to use
-pub use lean2md_core::{build_blocks, process_directory, Block};
+pub use lean2md_core::{build_blocks, process_directory, process_file, Block};

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Case: lean2md <file.lean>
             let src = PathBuf::from(&args[1]);
 
-            if src.is_file() && src.extension().map_or(false, |ext| ext == "lean") {
+            if src.is_file() && src.extension().is_some_and(|ext| ext == "lean") {
                 let tgt = src.with_extension("md");
                 return process_file(&src, &tgt);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,42 @@
-use lean2md::process_directory;
+use lean2md::{process_directory, process_file};
 use std::env;
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
 
-    if args.len() == 2 && args[1] == "--version" {
-        // Define version here since it's not exported from the library
-        let version = env!("CARGO_PKG_VERSION");
-        println!("lean2md version {}", version);
-        return Ok(());
+    if args.len() == 2 {
+        if args[1] == "--version" {
+            let version = env!("CARGO_PKG_VERSION");
+            println!("lean2md version {}", version);
+            return Ok(());
+        } else {
+            // Case: lean2md <file.lean>
+            let src = PathBuf::from(&args[1]);
+
+            if src.is_file() && src.extension().map_or(false, |ext| ext == "lean") {
+                let tgt = src.with_extension("md");
+                return process_file(&src, &tgt);
+            }
+        }
+    } else if args.len() == 3 {
+        let src = PathBuf::from(&args[1]);
+        let tgt = PathBuf::from(&args[2]);
+
+        if src.is_file() {
+            // Case: lean2md <lean_src_file> <md_tgt_file>
+            return process_file(&src, &tgt);
+        } else if src.is_dir() {
+            // Case: lean2md <lean_src_dir> <md_tgt_dir>
+            return process_directory(&src, &tgt);
+        }
     }
 
-    if args.len() != 3 {
-        println!("Usage: lean2md <lean_src_dir> <md_tgt_dir>");
-        return Ok(());
-    }
-
-    let src = PathBuf::from(&args[1]);
-    let tgt = PathBuf::from(&args[2]);
-
-    process_directory(&src, &tgt)?;
-
+    // If we reach here, arguments were invalid
+    println!("Usage:");
+    println!("  lean2md <file.lean>                  # Convert to <file.md>");
+    println!("  lean2md <lean_src_file> <md_tgt_file>   # Convert file to file");
+    println!("  lean2md <lean_src_dir> <md_tgt_dir>     # Convert directory to directory");
+    println!("  lean2md --version                    # Display version information");
     Ok(())
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -98,8 +98,6 @@ fn run_fixture_test(fixture_name: &str) {
     }
 }
 
-// Add these tests to tests/integration_tests.rs
-
 #[test]
 fn test_single_file_conversion() {
     // Create temporary directories

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -98,6 +98,80 @@ fn run_fixture_test(fixture_name: &str) {
     }
 }
 
+// Add these tests to tests/integration_tests.rs
+
+#[test]
+fn test_single_file_conversion() {
+    // Create temporary directories
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    // Create a test Lean file
+    let test_file = temp_dir.path().join("test_single.lean");
+    fs::write(&test_file, "/- Test comment -/\ndef example := 42").unwrap();
+
+    // Expected output file (same name with .md extension)
+    let expected_output = temp_dir.path().join("test_single.md");
+
+    // Run the program with single file argument
+    let output = std::process::Command::new("cargo")
+        .args(["run", "--", test_file.to_str().unwrap()])
+        .output()
+        .expect("Failed to execute process");
+
+    assert!(output.status.success(), "Command failed: {:?}", output);
+    assert!(expected_output.exists(), "Output file was not created");
+
+    // Verify content
+    let content = fs::read_to_string(expected_output).unwrap();
+    assert!(
+        content.contains("Test comment"),
+        "Output missing comment content"
+    );
+    assert!(
+        content.contains("def example := 42"),
+        "Output missing code content"
+    );
+}
+
+#[test]
+fn test_file_to_file_conversion() {
+    // Create temporary directories
+    let temp_in = tempfile::tempdir().unwrap();
+    let temp_out = tempfile::tempdir().unwrap();
+
+    // Create a test Lean file
+    let src_file = temp_in.path().join("input.lean");
+    fs::write(&src_file, "/- Another test -/\ndef another := 100").unwrap();
+
+    // Target file with different name
+    let tgt_file = temp_out.path().join("output.md");
+
+    // Run with explicit source and target
+    let output = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            src_file.to_str().unwrap(),
+            tgt_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute process");
+
+    assert!(output.status.success(), "Command failed: {:?}", output);
+    assert!(tgt_file.exists(), "Target file was not created");
+
+    // Verify content
+    let content = fs::read_to_string(tgt_file).unwrap();
+    assert!(
+        content.contains("Another test"),
+        "Output missing comment content"
+    );
+    assert!(
+        content.contains("def another := 100"),
+        "Output missing code content"
+    );
+}
+
 #[test]
 fn test_admonish() {
     run_fixture_test("admonish");


### PR DESCRIPTION
- Add `process_file` function to handle conversion of a single Lean file to Markdown
- Modify main function to support single file and file-to-file conversion cases
- Include integration tests for single file conversion and file-to-file conversion scenarios
- Update README with usage examples for single file and specific target conversions